### PR TITLE
feat: implement AI-powered flashcard generation endpoint

### DIFF
--- a/NotesWise.API/Endpoints/AIEndpoints.cs
+++ b/NotesWise.API/Endpoints/AIEndpoints.cs
@@ -15,6 +15,10 @@ public static class AIEndpoints
             .WithName("GenerateSummary")
             .WithOpenApi();
 
+        group.MapPost("generate-flashcards", GenerateFlashcards)
+            .WithName("GenerateFlashcards")
+            .WithOpenApi();
+
         group.MapPost("generate-audio", GenerateAudio)
             .WithName("GenerateAudio")
             .WithOpenApi();
@@ -52,6 +56,37 @@ public static class AIEndpoints
         }
     }
 
+    private static async Task<IResult> GenerateFlashcards(
+    HttpContext context,
+    GenerateFlashcardsRequest request,
+    IAiService aiService)
+    {
+        try
+        {
+            // Validate user is authenticated
+            //context.GetUserIdOrThrow();
+
+            if (string.IsNullOrWhiteSpace(request.Content))
+            {
+                return Results.BadRequest("Content is required");
+            }
+
+            var flashcards = await aiService.GenerateFlashcardsAsync(request.Content);
+
+            return Results.Ok(new GenerateFlashcardsResponse { Flashcards = flashcards });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Results.Unauthorized();
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem(
+                title: "Failed to generate flashcards",
+                detail: ex.Message,
+                statusCode: 500);
+        }
+    }
 
     private static async Task<IResult> GenerateAudio(
         HttpContext context,

--- a/NotesWise.API/Services/IAiService.cs
+++ b/NotesWise.API/Services/IAiService.cs
@@ -2,12 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NotesWise.API.Models;
+using NotesWise.API.Services.Models;
 
 namespace NotesWise.API.Services
 {
     public interface IAiService
     {
         Task<string> GenerateSummaryAsync(string content);
+        Task<List<FlashcardData>> GenerateFlashcardsAsync(string content);
         Task<string> GenerateAudioAsync(string text, string voice = "burt");
+        Task<GenerateFlashcardAudioResponse> GenerateFlashcardAudioAsync(Flashcard flashcard, string voice = "burt", string type = "both");
     }
 }

--- a/NotesWise.API/Services/Models/AiModels.cs
+++ b/NotesWise.API/Services/Models/AiModels.cs
@@ -17,6 +17,23 @@ namespace NotesWise.API.Services.Models
         public required string Summary { get; set; }
     }
 
+    public class GenerateFlashcardsRequest
+    {
+        public required string Content { get; set; }
+    }
+
+    public class GenerateFlashcardsResponse
+    {
+        public required List<FlashcardData> Flashcards { get; set; }
+    }
+
+    public class FlashcardData
+    {
+        public required string Question { get; set; }
+        public required string Answer { get; set; }
+    }
+
+
 
     public class GenerateAudioRequest
     {
@@ -29,26 +46,52 @@ namespace NotesWise.API.Services.Models
         public required string AudioContent { get; set; } // Base64 encoded audio
     }
 
+
+    public class GenerateFlashcardAudioRequest
+    {
+        public string Voice { get; set; } = "alloy";
+        public string Type { get; set; } = "question"; // "question", "answer", or "both"
+    }
+
+    public class GenerateFlashcardAudioResponse
+    {
+        public string? QuestionAudioContent { get; set; } // Base64 encoded audio for question
+        public string? AnswerAudioContent { get; set; } // Base64 encoded audio for answer
+    }
     //OpenAI API Models
     public class OpenAiRequest
     {
-        public string model { get; set; }
-        public string input { get; set; }
+        public string Model { get; set; }
+        public required List<OpenAiMessage> Input { get; set; }
+        public int? MaxOutputTokens { get; set; } = null;
+    }
+
+    public class OpenAiMessage
+    {
+        public required string Role { get; set; }
+        public required List<OpenAIContent> Content { get; set; }
+    }
+
+    public class OpenAIContent
+    {
+        public required string Type { get; set; }
+        public required string Text { get; set; }
     }
 
     public class OpenAiResponse
     {
-        public List<OpenAiOutput> output { get; set; }
+        public List<OpenAiOutput> Output { get; set; }
     }
 
     public class OpenAiOutput
     {
-        public List<OpenAiContent> content { get; set; }
+        public string Type { get; set; } = "";
+        public List<OpenAiContent> Content { get; set; }
     }
 
     public class OpenAiContent
     {
-        public string text { get; set; }
+        public string? Text { get; set; }
     }
 
     public class GeminiTextResponse


### PR DESCRIPTION
- Added /api/ai/generate-flashcards endpoint to generate study flashcards from provided content using OpenAI.
- Defined request and response models for flashcard generation (question/answer format).
- Ensured prompt instructs AI to return a JSON array of flashcards with 'question' and 'answer' fields.
- Improved error handling and validation for flashcard generation requests.